### PR TITLE
ci/cd: trigger workflow except deployment on opening a pull request

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
 
 jobs:
   simple_deployment_pipeline:


### PR DESCRIPTION
All the jobs in the deployment pipeline workflow should run except the deployment job which will only be run on merging with the main branch. 